### PR TITLE
FIX: sometimes there's no TERM variable in env

### DIFF
--- a/nicelog/formatters/__init__.py
+++ b/nicelog/formatters/__init__.py
@@ -106,7 +106,7 @@ class ColorLineFormatter(logging.Formatter):
         if os.environ.get('ANSI_COLORS_DISABLED') is not None:
             return None
         term = os.environ.get('TERM')
-        if '256color' in term:
+        if term and '256color' in term:
             return Xterm256Colorer()
         return Xterm16Colorer()
 


### PR DESCRIPTION
nicelog/formatters/**init**.py", line 109, in _get_colorer
    if '256color' in term:
TypeError: argument of type 'NoneType' is not iterable
